### PR TITLE
Goatools dependency update 1 0 3

### DIFF
--- a/megago/megago.py
+++ b/megago/megago.py
@@ -108,7 +108,7 @@ def get_highest_ic_anc(id, termcounts, godag):
     if termcounts.get(id, 0) > 0:
         return 0
     gosubdag_r0 = GoSubDag([id], godag, prt=None)
-    P = gosubdag_r0.rcntobj.go2parents[id]
+    P = gosubdag_r0.rcntobj.go2ancestors[id]
     max_ic = 0
     for i in P:
         ic = get_ic(i, termcounts,godag)

--- a/megago/similarty_metrics.ipynb
+++ b/megago/similarty_metrics.ipynb
@@ -216,7 +216,7 @@
    "source": [
     "def get_highest_ic_anc(id,termcounts):\n",
     "    gosubdag_r0 = GoSubDag([id], godag, prt=None)\n",
-    "    P = gosubdag_r0.rcntobj.go2parents[id]\n",
+    "    P = gosubdag_r0.rcntobj.go2ancestors[id]\n",
     "    max_ic = 0\n",
     "    for i in P:\n",
     "        ic = get_info_content(i, termcounts)\n",
@@ -495,6 +495,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.6"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Dependencies, with versions explicitly declared for development and testing
-goatools==0.9.9
+goatools==1.0.3
 seaborn
 # Packages that are not dependencies but used for building or testing
 pandas


### PR DESCRIPTION
The title says it all. The method `go2parents` will be deprecated and replaced by the method  `go2ancestors`. I changed the code accordingly.