### PR TITLE
Change similarity value for non-comparable GO-term/GO-term-sets from -1 to nan

### DIFF
--- a/functional_tests/testdata/example_input-compare_goa.csv.expected
+++ b/functional_tests/testdata/example_input-compare_goa.csv.expected
@@ -6,9 +6,9 @@ two levels higher 1,0.166453364022849
 two levels higher 2,0.310497729692692
 two levels higher 3,0.310529265600263
 four levels higher,0
-two unrelated bindings (MF vs BP) 1,-1
-two unrelated bindings (MF vs CC),-1
-two unrelated bindings (MF vs BP) 2,-1
+two unrelated bindings (MF vs BP) 1,nan
+two unrelated bindings (MF vs CC),nan
+two unrelated bindings (MF vs BP) 2,nan
 same level bindings (unrel) 1,0.495875632774122
 same level bindings (unrel) 2,0.378358216243867
 same level bindings (unrel) 3,0.898250923654065
@@ -17,7 +17,7 @@ two children of parent 2,0.964013200991831
 two children of parent (BP),0.368130797982323
 two children of binding VS two other children of binding,0.096992300641682
 two children of biological process VS two other children of biological process,0
-one report; other not (BP),-1
+one report; other not (BP),nan
 report specific; vs specific + parents,0.303819881883554
-one report; other not,-1
+one report; other not,nan
 unrelated (GTPase activity) vs binding (PPB) activity,0

--- a/megago/__init__.py
+++ b/megago/__init__.py
@@ -5,3 +5,4 @@ DATA_DIR = pkg_resources.resource_filename(__name__, 'resource_data')
 JSON_INDEXED_FILE_PATH = os.path.join(DATA_DIR, "go_freq_uniprot.json")
 UNIPROT_ASSOCIATIONS_FILE_PATH = os.path.join(DATA_DIR, "associations-uniprot-sp-20200116.tab")
 uniprot_time_stamp = ((UNIPROT_ASSOCIATIONS_FILE_PATH.split('-')[-1]).split('.'))[0]
+NAN_VALUE = -1

--- a/megago/__init__.py
+++ b/megago/__init__.py
@@ -5,4 +5,4 @@ DATA_DIR = pkg_resources.resource_filename(__name__, 'resource_data')
 JSON_INDEXED_FILE_PATH = os.path.join(DATA_DIR, "go_freq_uniprot.json")
 UNIPROT_ASSOCIATIONS_FILE_PATH = os.path.join(DATA_DIR, "associations-uniprot-sp-20200116.tab")
 uniprot_time_stamp = ((UNIPROT_ASSOCIATIONS_FILE_PATH.split('-')[-1]).split('.'))[0]
-NAN_VALUE = -1
+NAN_VALUE = float('nan')


### PR DESCRIPTION
Fix #9 

Rel_Metric returns `float('nan')` if 
- one of the go terms is not in the got term tree (goatools `godag`)
- go terms are from different namespaces

BMA function for averaging of multiple similary values returns `float('nan')` if
- all individual GO term comparisons returned `float('nan')`
- one GO term set is empty, the other is not