### PR TITLE
Fix division by zero error #21

### DIFF
--- a/megago/metrics.py
+++ b/megago/metrics.py
@@ -170,4 +170,8 @@ def compute_bma_metric(go_list1, go_list2, term_counts, go_dag, highest_ic_anc, 
         for id1 in go_list1:
             similarity_values.append(similarity_method(id2, id1, go_dag, term_counts, highest_ic_anc))
         summation_set21 += max(similarity_values + [NAN_VALUE])
-    return (summation_set12 + summation_set21) / (len(go_list1) + len(go_list2))
+    if (len(go_list1) + len(go_list2)) == 0:
+        bma = 0
+    else:
+        bma = (summation_set12 + summation_set21) / (len(go_list1) + len(go_list2))
+    return bma

--- a/megago/metrics.py
+++ b/megago/metrics.py
@@ -158,6 +158,36 @@ def rel_metric(go_id1, go_id2, go_dag, term_counts, highest_ic_anc):
 
 
 def compute_bma_metric(go_list1, go_list2, term_counts, go_dag, highest_ic_anc, similarity_method=rel_metric):
+    """calculate the best match average similarity of the two provided sets of go terms
+
+    For each GO term in go_list1, the similarity value of the most similar term from go_list2 is picked. The sum of
+    these highest similarity values is divided by the total number of GO terms in go_list1 and go_list2. The metric
+    is implemented according to: Schlicker, A., Domingues, F.S., Rahnenführer, J. et al. A new measure for functional
+    similarity of gene products based on Gene Ontology. BMC Bioinformatics 7, 302 (2006) doi:10.1186/1471-2105-7-302
+
+    Parameters
+    ----------
+    go_list1 : iterable
+        iterable, containing go term strings
+    go_list2 : iterable
+        iterable, containing go term strings
+    term_counts : dict
+        dictionary: key: GO terms, values: number of occurrences of GO term and its children in body of evidence
+    go_dag : GODag object
+        GODag object from the goatools package
+    highest_ic_anc : dict
+        dictionary: key: GO terms, values: information content of the ancestor with the highest information content
+    similarity_method : function
+        function with the following arguments: id1, id2, go_dag, term_counts, highest_ic_anc
+        must return a float or the value of the global variable NAN_VALUE.
+
+
+    Returns
+    -------
+    float
+
+    """
+
     summation_set12 = 0.0
     summation_set21 = 0.0
     for id1 in go_list1:


### PR DESCRIPTION
- fix #21 : division by zero error in method compute_bma_metric. Fixed by returning 0 if both sets of GO terms are empty
- add docstring to method compute_bma_metric
